### PR TITLE
Concurrent semantics

### DIFF
--- a/src/main/java/edu/kit/kastel/property/packing/PackingAnnotatedTypeFactory.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingAnnotatedTypeFactory.java
@@ -159,6 +159,8 @@ public class PackingAnnotatedTypeFactory
             // Exclusivity checker considers unassigned fields with default value null unique
             if (factory instanceof ExclusivityAnnotatedTypeFactory exclFactory) {
                 refType.replaceAnnotations(List.of(exclFactory.UNIQUE));
+            } else if (factory instanceof NullnessLatticeAnnotatedTypeFactory nullnessFactory && refType.getKind().isPrimitive()) {
+                refType.replaceAnnotations(List.of(nullnessFactory.getNonNull()));
             } else {
                 refType.replaceAnnotations(factory.getQualifierHierarchy().getTopAnnotations());
             }

--- a/src/main/java/edu/kit/kastel/property/packing/PackingClientAnnotatedTypeFactory.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingClientAnnotatedTypeFactory.java
@@ -8,6 +8,7 @@ import org.checkerframework.dataflow.cfg.node.*;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizer;
 import org.checkerframework.dataflow.cfg.visualize.DOTCFGVisualizer;
 import org.checkerframework.dataflow.expression.JavaExpression;
+import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
@@ -195,6 +196,14 @@ public abstract class PackingClientAnnotatedTypeFactory<
             checkerName = checkerName.substring(0, checkerName.length() - "Subchecker".length());
         }
         return checkerName;
+    }
+
+    public PackingChecker getPackingChecker() {
+        SourceChecker result = checker.getParentChecker();
+        while (!(result instanceof PackingChecker)) {
+            result = result.getParentChecker();
+        }
+        return (PackingChecker) result;
     }
 
     public boolean isMonotonicMethod(MethodTree tree) {

--- a/src/main/java/edu/kit/kastel/property/packing/PackingClientStore.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingClientStore.java
@@ -1,11 +1,17 @@
 package edu.kit.kastel.property.packing;
 
+import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityAnnotatedTypeFactory;
+import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityChecker;
+import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityStore;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.LocalVariable;
 import org.checkerframework.dataflow.expression.ThisReference;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAbstractStore;
+
+import java.util.function.BinaryOperator;
 
 public abstract class PackingClientStore<V extends PackingClientValue<V>, S extends PackingClientStore<V, S>>
         extends CFAbstractStore<V, S> {
@@ -30,6 +36,41 @@ public abstract class PackingClientStore<V extends PackingClientValue<V>, S exte
                 value,
                 (old, newValue) -> newValue,
                 permitNondeterministic);
+    }
+
+    @Override
+    protected void computeNewValueAndInsert(JavaExpression expr, @Nullable V value, BinaryOperator<V> merger, boolean permitNondeterministic) {
+        if (sequentialSemantics || !(expr instanceof FieldAccess)) {
+            super.computeNewValueAndInsert(expr, value, merger, permitNondeterministic);
+        } else {
+            // Always use sequential semantics for field accesses if the receiver is Unique
+            FieldAccess fieldAcc = (FieldAccess) expr;
+            if (isCurrentReceiverUnique() || isMonotonicUpdate(fieldAcc, value) || fieldAcc.isUnassignableByOtherCode()) {
+                V oldValue = fieldValues.get(fieldAcc);
+                V newValue = merger.apply(oldValue, value);
+                if (newValue != null) {
+                    fieldValues.put(fieldAcc, newValue);
+                }
+            }
+        }
+    }
+
+    protected void updateForFieldAccessAssignment(FieldAccess fieldAccess, @Nullable V val) {
+        removeConflicting(fieldAccess, val);
+        if (!fieldAccess.containsUnknown() && val != null) {
+            // Always use sequential semantics for field accesses if the receiver is Unique
+            if (sequentialSemantics || isCurrentReceiverUnique()
+                    || isMonotonicUpdate(fieldAccess, val)
+                    || fieldAccess.isUnassignableByOtherCode()) {
+                fieldValues.put(fieldAccess, val);
+            }
+        }
+    }
+
+    protected boolean isCurrentReceiverUnique() {
+        ExclusivityAnnotatedTypeFactory exclFactory = getFactory().getPackingChecker().getTypeFactoryOfSubcheckerOrNull(ExclusivityChecker.class);
+        ExclusivityStore exclStore = exclFactory.getStoreBefore(((PackingClientAnalysis) analysis).getLocalTree());
+        return exclStore != null && exclStore.thisValue.getAnnotations().contains(exclFactory.UNIQUE);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/edu/kit/kastel/property/packing/PackingClientStore.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingClientStore.java
@@ -70,7 +70,7 @@ public abstract class PackingClientStore<V extends PackingClientValue<V>, S exte
     protected boolean isCurrentReceiverUnique() {
         ExclusivityAnnotatedTypeFactory exclFactory = getFactory().getPackingChecker().getTypeFactoryOfSubcheckerOrNull(ExclusivityChecker.class);
         ExclusivityStore exclStore = exclFactory.getStoreBefore(((PackingClientAnalysis) analysis).getLocalTree());
-        return exclStore != null && exclStore.thisValue.getAnnotations().contains(exclFactory.UNIQUE);
+        return exclStore != null && exclStore.thisValue != null && exclStore.thisValue.getAnnotations().contains(exclFactory.UNIQUE);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
@@ -86,6 +86,13 @@ public class PackingStore extends InitializationAbstractStore<CFValue, PackingSt
         }
     }
 
+    @Override
+    protected boolean isDeclaredInitialized(FieldAccess fieldAccess) {
+        // Ignore declared Initialized type when updating field values after a method call,
+        // to ensure sound treatment of non-monotonic methods.
+        return false;
+    }
+
     /**
      * Whether a helper function, i.e., a function that may leave the receiver not @Initialized was called on {@code this}.
      *
@@ -95,8 +102,8 @@ public class PackingStore extends InitializationAbstractStore<CFValue, PackingSt
         return helperFunctionCalled;
     }
 
-    public void setHelperFunctionCalled(boolean helperFunctionCalled) {
-        this.helperFunctionCalled = helperFunctionCalled;
+    public void helperFunctionWasCalled() {
+        this.helperFunctionCalled = true;
     }
 
     public boolean isDependableFieldAssigned() {

--- a/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
@@ -3,12 +3,19 @@ package edu.kit.kastel.property.packing;
 import org.checkerframework.checker.initialization.InitializationAbstractStore;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.node.ThisNode;
 import org.checkerframework.dataflow.expression.*;
 import org.checkerframework.framework.flow.CFValue;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.TypesUtils;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+import java.util.stream.Stream;
 
 public class PackingStore extends InitializationAbstractStore<CFValue, PackingStore> {
 
@@ -73,7 +80,10 @@ public class PackingStore extends InitializationAbstractStore<CFValue, PackingSt
     }
 
     @Override
-    public void updateForMethodCall(MethodInvocationNode methodInvocationNode, GenericAnnotatedTypeFactory<CFValue, PackingStore, ?, ?> atypeFactory, CFValue val) {
+    public void updateForMethodCall(
+            MethodInvocationNode methodInvocationNode,
+            GenericAnnotatedTypeFactory<CFValue, PackingStore, ?, ?> atypeFactory,
+            CFValue val) {
         ExecutableElement method = methodInvocationNode.getTarget().getMethod();
 
         if (((PackingFieldAccessAnnotatedTypeFactory) atypeFactory).isMonotonicMethod(method)) {
@@ -81,8 +91,58 @@ public class PackingStore extends InitializationAbstractStore<CFValue, PackingSt
             JavaExpression methodCall = JavaExpression.fromNode(methodInvocationNode);
             replaceValue(methodCall, val);
         } else {
-            // change the store normally
-            super.updateForMethodCall(methodInvocationNode, atypeFactory, val);
+            updateForNonMonotonicMethodCall(methodInvocationNode, atypeFactory, val);
+        }
+    }
+
+    private void updateForNonMonotonicMethodCall(
+            MethodInvocationNode node,
+            GenericAnnotatedTypeFactory<CFValue, PackingStore, ?, ?> atypeFactory,
+            CFValue val
+    ) {
+        super.updateForMethodCall(node, atypeFactory, val);
+
+        MethodCall invocation = (MethodCall) JavaExpression.fromNode(node);
+        ExecutableElement method = invocation.getElement();
+
+        if (atypeFactory.isSideEffectFree(method) && atypeFactory.isDeterministic(method)) {
+            // insert return value into store if method is pure and not a constructor call (like this(...) or super(...))
+            if (method.getKind() != ElementKind.CONSTRUCTOR || invocation.getReceiver() instanceof ClassName) {
+                insertValue(invocation, val);
+            }
+            return;
+        }
+
+        // If `this` was passed to the method call, we first clear all field values, then restore some field values
+        // based on the method signature.
+        boolean thisPassed = Stream.concat(Stream.of(invocation.getReceiver()), invocation.getArguments().stream())
+                .anyMatch(v -> v instanceof ThisReference);
+        if (!thisPassed) {
+            return;
+        }
+        fieldValues.clear();
+
+        PackingFieldAccessAnnotatedTypeFactory packingFactory = (PackingFieldAccessAnnotatedTypeFactory) atypeFactory;
+        CFValue outputPackingValue = getValue((ThisNode) null);
+
+        if (outputPackingValue != null) {
+            TypeMirror thisType = outputPackingValue.getUnderlyingType();
+            AnnotatedTypeMirror outputPackingType = AnnotatedTypeMirror.createType(thisType, packingFactory, false);
+            outputPackingType.addAnnotations(outputPackingValue.getAnnotations());
+            var packingAnno = outputPackingType.getAnnotationInHierarchy(packingFactory.getUnknownInitialization());
+
+            TypeMirror frame;
+            if (packingFactory.isInitialized(packingAnno)) {
+                frame = thisType;
+            } else {
+                frame = packingFactory.getTypeFrameFromAnnotation(packingAnno);
+            }
+
+            var initializedFields = ElementUtils.getAllFieldsIn(TypesUtils.getTypeElement(frame), packingFactory.getElementUtils());
+            for (var field : initializedFields) {
+                AnnotatedTypeMirror adaptedType = analysis.getTypeFactory().getAnnotatedType(field);
+                insertValue(new FieldAccess(new ThisReference(thisType), field), analysis.createAbstractValue(adaptedType));
+            }
         }
     }
 

--- a/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingStore.java
@@ -86,13 +86,6 @@ public class PackingStore extends InitializationAbstractStore<CFValue, PackingSt
         }
     }
 
-    @Override
-    protected boolean isDeclaredInitialized(FieldAccess fieldAccess) {
-        // Ignore declared Initialized type when updating field values after a method call,
-        // to ensure sound treatment of non-monotonic methods.
-        return false;
-    }
-
     /**
      * Whether a helper function, i.e., a function that may leave the receiver not @Initialized was called on {@code this}.
      *

--- a/src/main/java/edu/kit/kastel/property/packing/PackingTransfer.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingTransfer.java
@@ -275,9 +275,7 @@ public class PackingTransfer extends InitializationAbstractTransfer<CFValue, Pac
                             expr,
                             paramDefaultValue.mostSpecific(oldValue, paramDefaultValue));
                 } else {
-                    store.replaceValue(
-                            expr,
-                            paramDefaultValue);
+                    store.replaceValue(expr, paramDefaultValue);
                 }
             }
         } else {

--- a/src/main/java/edu/kit/kastel/property/packing/PackingTransfer.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingTransfer.java
@@ -137,9 +137,9 @@ public class PackingTransfer extends InitializationAbstractTransfer<CFValue, Pac
 
         if (n.getTarget().getReceiver() instanceof ThisNode
                 && (n.getTarget().getMethod().getReceiverType().getAnnotation(UnderInitialization.class) != null
-                    || n.getTarget().getMethod().getReceiverType().getAnnotation(UnderInitialization.class) != null)) {
+                    || n.getTarget().getMethod().getReceiverType().getAnnotation(UnknownInitialization.class) != null)) {
             TransferResult<CFValue, PackingStore> result = super.visitMethodInvocation(n, in);
-            result.getRegularStore().setHelperFunctionCalled(true);
+            result.getRegularStore().helperFunctionWasCalled();
             return result;
         }
 
@@ -299,7 +299,7 @@ public class PackingTransfer extends InitializationAbstractTransfer<CFValue, Pac
                 JavaExpression je = stringToJavaExpr.toJavaExpression(expressionString);
 
                 if (je.toString().equals("this") && !atypeFactory.isInitialized(anno)) {
-                    store.setHelperFunctionCalled(true);
+                    store.helperFunctionWasCalled();
                 }
 
                 // Unlike the superclass implementation, this calls

--- a/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
@@ -583,7 +583,7 @@ public class PackingVisitor
                 CFAbstractStore<?, ?> store = targetChecker.getTypeFactory().getStoreAfter(getCurrentPath().getLeaf());
 
                 AnnotatedTypeMirror declType = factory.getAnnotatedType(field);
-                AnnotatedTypeMirror refType = PackingAnnotatedTypeFactory.getRefinedTypeInCurrentClass(factory, store, currentClass, field);
+                AnnotatedTypeMirror refType = factory.getAnnotatedType(valueExp);
                 // MonotonicNonNull fields may be null
                 if (declType.hasAnnotation(MonotonicNonNull.class) && refType.hasAnnotation(Nullable.class)) {
                     break;

--- a/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
@@ -81,6 +81,12 @@ public class PackingVisitor
             Tree valueTree,
             @CompilerMessageKey String errorKey,
             Object... extraArgs) {
+        // Primitives are always initialized
+        if (varType.getKind().isPrimitive()) {
+            return;
+        }
+
+        // Try to infer a packing statement to avoid the error
         if (valueTree.toString().equals("this")
                 && canInferPackingStatement(
                         valueTree,

--- a/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
+++ b/src/main/java/edu/kit/kastel/property/packing/PackingVisitor.java
@@ -846,11 +846,7 @@ public class PackingVisitor
                         }
                     } else {
                         // Issue all the errors at the relevant constructor
-                        StringJoiner fieldsString = new StringJoiner(", ");
-                        for (VariableElement f : uninitializedFields) {
-                            fieldsString.add(f.getSimpleName());
-                        }
-                        targetChecker.reportError(tree, errorMsg, fieldsString);
+                        reportUninitializedFieldsError(tree, targetChecker, uninitializedFields);
                     }
                 }
             }

--- a/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
@@ -95,8 +95,9 @@ public final class LatticeStore extends PackingClientStore<LatticeValue, Lattice
 			// the util method takes this into account when searching for dependencies.
 			exprAnalyzer = expr -> JavaExpressionUtil.maybeDependent(expr, fieldAccess, currentTree, exclFactory);
 		} else if (dependency instanceof ThisReference) {
-			// clear all fields
-			fieldValues.clear();
+			// Clear all fields for now. Committed fields get set to their declared type by
+			// `updateCommittedFields` later.
+		    fieldValues.clear();
 			exprAnalyzer = expr -> expr.containsSyntacticEqualJavaExpression(dependency);
 		} else {
 			// then it's a local variable, and dependencies on local variables cannot
@@ -299,17 +300,19 @@ public final class LatticeStore extends PackingClientStore<LatticeValue, Lattice
 
 		CFValue outputPackingValue = storeAfter.getValue((ThisNode) null);
 
-		if (thisValue == null) {
-			return;
-		}
-
-		TypeMirror thisType = thisValue.getUnderlyingType();
-		AnnotatedTypeMirror outputPackingType = AnnotatedTypeMirror.createType(thisType,
-				packingFactory, false);
 		if (outputPackingValue != null) {
+			TypeMirror thisType = outputPackingValue.getUnderlyingType();
+			AnnotatedTypeMirror outputPackingType = AnnotatedTypeMirror.createType(thisType, packingFactory, false);
 			outputPackingType.addAnnotations(outputPackingValue.getAnnotations());
 			var packingAnno = outputPackingType.getAnnotationInHierarchy(packingFactory.getUnknownInitialization());
-			var frame = packingFactory.getTypeFrameFromAnnotation(packingAnno);
+
+			TypeMirror frame;
+			if (packingFactory.isInitialized(packingAnno)) {
+				frame = thisType;
+			} else {
+				frame = packingFactory.getTypeFrameFromAnnotation(packingAnno);
+			}
+			
 			var initializedFields = ElementUtils.getAllFieldsIn(TypesUtils.getTypeElement(frame), packingFactory.getElementUtils());
 			for (var field : initializedFields) {
 				AnnotatedTypeMirror adaptedType = analysis.getTypeFactory().getAnnotatedType(field);

--- a/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
@@ -312,7 +312,7 @@ public final class LatticeStore extends PackingClientStore<LatticeValue, Lattice
 			} else {
 				frame = packingFactory.getTypeFrameFromAnnotation(packingAnno);
 			}
-			
+
 			var initializedFields = ElementUtils.getAllFieldsIn(TypesUtils.getTypeElement(frame), packingFactory.getElementUtils());
 			for (var field : initializedFields) {
 				AnnotatedTypeMirror adaptedType = analysis.getTypeFactory().getAnnotatedType(field);

--- a/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeStore.java
@@ -94,8 +94,12 @@ public final class LatticeStore extends PackingClientStore<LatticeValue, Lattice
 			// dependency on fields may be expressed through aliases of the field owner object.
 			// the util method takes this into account when searching for dependencies.
 			exprAnalyzer = expr -> JavaExpressionUtil.maybeDependent(expr, fieldAccess, currentTree, exclFactory);
+		} else if (dependency instanceof ThisReference) {
+			// clear all fields
+			fieldValues.clear();
+			exprAnalyzer = expr -> expr.containsSyntacticEqualJavaExpression(dependency);
 		} else {
-			// if it's not a field access, it's a local variable, and dependencies on local variables cannot
+			// then it's a local variable, and dependencies on local variables cannot
 			// exist through a layer of aliases.
 			exprAnalyzer = expr -> expr.containsSyntacticEqualJavaExpression(dependency);
 		}

--- a/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeTransfer.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/lattice/LatticeTransfer.java
@@ -20,6 +20,7 @@ import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.JCTree;
 import edu.kit.kastel.property.lattice.EvaluatedPropertyAnnotation;
 import edu.kit.kastel.property.lattice.Lattice;
 import edu.kit.kastel.property.lattice.PropertyAnnotation;
@@ -27,7 +28,6 @@ import edu.kit.kastel.property.lattice.PropertyAnnotationType;
 import edu.kit.kastel.property.packing.PackingClientTransfer;
 import edu.kit.kastel.property.packing.PackingFieldAccessAnnotatedTypeFactory;
 import edu.kit.kastel.property.packing.PackingFieldAccessSubchecker;
-import edu.kit.kastel.property.util.ClassUtils;
 import edu.kit.kastel.property.util.Packing;
 import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
@@ -153,8 +153,7 @@ public final class LatticeTransfer extends PackingClientTransfer<LatticeValue, L
                 PropertyAnnotationType pat = epa.getAnnotationType();
 
                 if (pat.getSubjectType() != null) {
-                    Class<?> literalClass = ClassUtils.literalKindToClass(literal.getKind());
-                    if (literalClass != null && literalClass.equals(pat.getSubjectType())) {
+                    if (TypesUtils.areSamePrimitiveTypes(((JCTree) literal).type, pat.getSubjectType())) {
                         if (epa.checkProperty(literal.getValue())) {
                             compatible = true;
                         }

--- a/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeAnalysis.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeAnalysis.java
@@ -1,8 +1,10 @@
 package edu.kit.kastel.property.subchecker.nullness;
 
+import com.sun.source.tree.Tree;
 import org.checkerframework.checker.nullness.NullnessNoInitAnalysis;
 import org.checkerframework.checker.nullness.NullnessNoInitAnnotatedTypeFactory;
 import org.checkerframework.checker.nullness.NullnessNoInitStore;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
 public class NullnessLatticeAnalysis extends NullnessNoInitAnalysis {
@@ -24,5 +26,24 @@ public class NullnessLatticeAnalysis extends NullnessNoInitAnalysis {
     @Override
     public NullnessNoInitStore createCopiedStore(NullnessNoInitStore s) {
         return new NullnessLatticeStore(s);
+    }
+
+
+    // TODO: Duplicated logic from PackingClientAnalysis
+
+    private Tree position = null;
+    /**
+     * Returns the tree currently set to be the context for determining the uniqueness of the receiver
+     * This must be set and kept up to date by PackingClientTransfer and its sub classes via {@link #setPosition(Tree)}.
+     *
+     * @return A {@code Tree}.
+     */
+    @Nullable
+    public Tree getLocalTree() {
+        return position;
+    }
+
+    public void setPosition(@Nullable Tree position) {
+        this.position = position;
     }
 }

--- a/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeAnnotatedTypeFactory.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeAnnotatedTypeFactory.java
@@ -7,6 +7,7 @@ import edu.kit.kastel.property.lattice.Lattice;
 import edu.kit.kastel.property.lattice.PropertyAnnotation;
 import edu.kit.kastel.property.lattice.PropertyAnnotationType;
 import edu.kit.kastel.property.lattice.SubAnnotationRelation;
+import edu.kit.kastel.property.packing.PackingChecker;
 import edu.kit.kastel.property.packing.PackingFieldAccessAnnotatedTypeFactory;
 import edu.kit.kastel.property.packing.PackingFieldAccessSubchecker;
 import edu.kit.kastel.property.packing.PackingFieldAccessTreeAnnotator;
@@ -26,6 +27,7 @@ import org.checkerframework.dataflow.expression.LocalVariable;
 import org.checkerframework.dataflow.expression.ThisReference;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAbstractStore;
+import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
@@ -208,6 +210,14 @@ public class NullnessLatticeAnnotatedTypeFactory extends NullnessNoInitAnnotated
 
     public AnnotationMirror getNullable() {
         return NULLABLE;
+    }
+
+    public PackingChecker getPackingChecker() {
+        SourceChecker result = checker.getParentChecker();
+        while (!(result instanceof PackingChecker)) {
+            result = result.getParentChecker();
+        }
+        return (PackingChecker) result;
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeStore.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeStore.java
@@ -5,6 +5,7 @@ import edu.kit.kastel.property.packing.PackingFieldAccessSubchecker;
 import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityAnnotatedTypeFactory;
 import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityChecker;
 import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityStore;
+import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityValue;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.NullnessNoInitStore;
 import org.checkerframework.checker.nullness.NullnessNoInitValue;
@@ -72,7 +73,11 @@ public class NullnessLatticeStore extends NullnessNoInitStore {
     protected boolean isCurrentReceiverUnique() {
         ExclusivityAnnotatedTypeFactory exclFactory = getFactory().getPackingChecker().getTypeFactoryOfSubcheckerOrNull(ExclusivityChecker.class);
         ExclusivityStore exclStore = exclFactory.getStoreBefore(((NullnessLatticeAnalysis) analysis).getLocalTree());
-        return exclStore != null && exclStore.getValue((ThisNode) null).getAnnotations().contains(exclFactory.UNIQUE);
+        if (exclStore != null) {
+            ExclusivityValue thisValue = exclStore.getValue((ThisNode) null);
+            return thisValue != null && thisValue.getAnnotations().contains(exclFactory.UNIQUE);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeStore.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeStore.java
@@ -4,13 +4,16 @@ import edu.kit.kastel.property.packing.PackingFieldAccessAnnotatedTypeFactory;
 import edu.kit.kastel.property.packing.PackingFieldAccessSubchecker;
 import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityAnnotatedTypeFactory;
 import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityChecker;
+import edu.kit.kastel.property.subchecker.exclusivity.ExclusivityStore;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.NullnessNoInitStore;
 import org.checkerframework.checker.nullness.NullnessNoInitValue;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ThisNode;
 import org.checkerframework.dataflow.expression.FieldAccess;
+import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -20,6 +23,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 
 public class NullnessLatticeStore extends NullnessNoInitStore {
 
@@ -29,6 +33,46 @@ public class NullnessLatticeStore extends NullnessNoInitStore {
 
     public NullnessLatticeStore(NullnessNoInitStore s) {
         super(s);
+    }
+
+    @SuppressWarnings("unchecked")
+    NullnessLatticeAnnotatedTypeFactory getFactory() {
+        return (NullnessLatticeAnnotatedTypeFactory) analysis.getTypeFactory();
+    }
+
+    @Override
+    protected void computeNewValueAndInsert(JavaExpression expr, @Nullable NullnessNoInitValue value, BinaryOperator<NullnessNoInitValue> merger, boolean permitNondeterministic) {
+        if (sequentialSemantics || !(expr instanceof FieldAccess)) {
+            super.computeNewValueAndInsert(expr, value, merger, permitNondeterministic);
+        } else {
+            // Always use sequential semantics for field accesses if the receiver is Unique
+            FieldAccess fieldAcc = (FieldAccess) expr;
+            if (isCurrentReceiverUnique() || isMonotonicUpdate(fieldAcc, value) || fieldAcc.isUnassignableByOtherCode()) {
+                NullnessNoInitValue oldValue = fieldValues.get(fieldAcc);
+                NullnessNoInitValue newValue = merger.apply(oldValue, value);
+                if (newValue != null) {
+                    fieldValues.put(fieldAcc, newValue);
+                }
+            }
+        }
+    }
+
+    protected void updateForFieldAccessAssignment(FieldAccess fieldAccess, @Nullable NullnessNoInitValue val) {
+        removeConflicting(fieldAccess, val);
+        if (!fieldAccess.containsUnknown() && val != null) {
+            // Always use sequential semantics for field accesses if the receiver is Unique
+            if (sequentialSemantics || isCurrentReceiverUnique()
+                    || isMonotonicUpdate(fieldAccess, val)
+                    || fieldAccess.isUnassignableByOtherCode()) {
+                fieldValues.put(fieldAccess, val);
+            }
+        }
+    }
+
+    protected boolean isCurrentReceiverUnique() {
+        ExclusivityAnnotatedTypeFactory exclFactory = getFactory().getPackingChecker().getTypeFactoryOfSubcheckerOrNull(ExclusivityChecker.class);
+        ExclusivityStore exclStore = exclFactory.getStoreBefore(((NullnessLatticeAnalysis) analysis).getLocalTree());
+        return exclStore != null && exclStore.getValue((ThisNode) null).getAnnotations().contains(exclFactory.UNIQUE);
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeTransfer.java
+++ b/src/main/java/edu/kit/kastel/property/subchecker/nullness/NullnessLatticeTransfer.java
@@ -9,8 +9,13 @@ import org.checkerframework.checker.nullness.NullnessNoInitAnalysis;
 import org.checkerframework.checker.nullness.NullnessNoInitStore;
 import org.checkerframework.checker.nullness.NullnessNoInitTransfer;
 import org.checkerframework.checker.nullness.NullnessNoInitValue;
+import org.checkerframework.dataflow.analysis.TransferInput;
+import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
+import org.checkerframework.dataflow.cfg.node.AssignmentNode;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.ThisReference;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -31,6 +36,7 @@ public class NullnessLatticeTransfer extends NullnessNoInitTransfer {
 
     @Override
     public NullnessNoInitStore initialStore(UnderlyingAST underlyingAST, List<LocalVariableNode> parameters) {
+        ((NullnessLatticeAnalysis) analysis).setPosition(underlyingAST.getCode());
         NullnessNoInitStore initStore = super.initialStore(underlyingAST, parameters);
 
         if (underlyingAST.getKind() == UnderlyingAST.Kind.METHOD) {
@@ -89,5 +95,23 @@ public class NullnessLatticeTransfer extends NullnessNoInitTransfer {
         }
 
         return initStore;
+    }
+
+    @Override
+    public TransferResult<NullnessNoInitValue, NullnessNoInitStore> visitAssignment(AssignmentNode n, TransferInput<NullnessNoInitValue, NullnessNoInitStore> in) {
+        ((NullnessLatticeAnalysis) analysis).setPosition(n.getTree());
+        return super.visitAssignment(n, in);
+    }
+
+    @Override
+    public TransferResult<NullnessNoInitValue, NullnessNoInitStore> visitMethodInvocation(MethodInvocationNode n, TransferInput<NullnessNoInitValue, NullnessNoInitStore> in) {
+        ((NullnessLatticeAnalysis) analysis).setPosition(n.getTree());
+        return super.visitMethodInvocation(n, in);
+    }
+
+    @Override
+    public TransferResult<NullnessNoInitValue, NullnessNoInitStore> visitObjectCreation(ObjectCreationNode n, TransferInput<NullnessNoInitValue, NullnessNoInitStore> p) {
+        ((NullnessLatticeAnalysis) analysis).setPosition(n.getTree());
+        return super.visitObjectCreation(n, p);
     }
 }

--- a/src/test/java/tests/property/ConcurrentSemanticsTest.java
+++ b/src/test/java/tests/property/ConcurrentSemanticsTest.java
@@ -1,0 +1,39 @@
+/* This file is part of the Property Checker.
+ * Copyright (c) 2021 -- present. Property Checker developers.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details.
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package tests.property;
+
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+@SuppressWarnings("nls")
+public class ConcurrentSemanticsTest extends PropertyCheckerTest {
+    public ConcurrentSemanticsTest (List<File> testFiles) {
+        super(
+                testFiles,
+                "tests/property/lattice_interval",
+                "tests/property/ConcurrentSemanticsTest/",
+                "edu.kit.kastel.property.subchecker.lattice.qual",
+                "-AconcurrentSemantics");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"property/ConcurrentSemanticsTest"};
+    }
+}

--- a/src/test/java/tests/property/ConcurrentSemanticsTestSequential.java
+++ b/src/test/java/tests/property/ConcurrentSemanticsTestSequential.java
@@ -1,0 +1,39 @@
+/* This file is part of the Property Checker.
+ * Copyright (c) 2021 -- present. Property Checker developers.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details.
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package tests.property;
+
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.List;
+
+@SuppressWarnings("nls")
+public class ConcurrentSemanticsTestSequential extends PropertyCheckerTest {
+    public ConcurrentSemanticsTestSequential(List<File> testFiles) {
+        super(
+                testFiles,
+                "tests/property/lattice_interval",
+                "tests/property/ConcurrentSemanticsTestSequential/",
+                "edu.kit.kastel.property.subchecker.lattice.qual"//,
+                /*"-AconcurrentSemantics"*/);
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"property/ConcurrentSemanticsTestSequential"};
+    }
+}

--- a/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
@@ -1,0 +1,66 @@
+import edu.kit.kastel.property.util.Packing;
+import edu.kit.kastel.property.checker.qual.*;
+import edu.kit.kastel.property.subchecker.exclusivity.qual.*;
+import edu.kit.kastel.property.subchecker.lattice.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+import edu.kit.kastel.property.packing.qual.*;
+import org.checkerframework.checker.initialization.qual.*;
+
+public final class ConcurrentSemanticsTest {
+
+    public int intField;
+    public @Nullable Object objField;
+
+    @EnsuresMaybeAliased(value="this")
+    public void leakThis(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {}
+
+    // this is aliased; thus another thread may write the field
+
+    public @Interval(min="2", max="2") int aliasedInt(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
+    public @NonNull Object aliasedObj(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+        // :: error: nullness.return.type.incompatible :: error: packing.return.type.incompatible
+        return objField;
+    }
+
+    // this is unique and becomes aliased; thus another thread may write the field
+
+    @EnsuresMaybeAliased(value="this")
+    public @Interval(min="2", max="2") int aliasedLaterInt(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        this.leakThis();
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
+    @EnsuresMaybeAliased(value="this")
+    public @NonNull Object aliasedLaterObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+        this.leakThis();
+        // :: error: nullness.return.type.incompatible :: error: packing.return.type.incompatible
+        return objField;
+    }
+
+    // this remains unique; thus the field cannot be written by another thread
+
+    public @Interval(min="2", max="2") int uniqueInt(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        return intField;
+    }
+    public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+
+        // TODO This error is a false positive, but fixing requires
+        //  either introducing a circular dependency between the packing and uniqueness checkers
+        //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
+        //  in the paper.
+        // :: error: packing.return.type.incompatible
+        return objField;
+    }
+}

--- a/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
@@ -6,9 +6,11 @@ import org.checkerframework.checker.nullness.qual.*;
 import edu.kit.kastel.property.packing.qual.*;
 import org.checkerframework.checker.initialization.qual.*;
 
+
+
 public final class ConcurrentSemanticsTest {
 
-    public int intField;
+    public @Interval(min="0", max="9") int intField = 3;
     public @Nullable Object objField;
 
     @EnsuresMaybeAliased(value="this")
@@ -17,6 +19,12 @@ public final class ConcurrentSemanticsTest {
     // this is aliased; thus another thread may write the field
 
     public @Interval(min="2", max="2") int aliasedInt(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
+    public @Interval(min="0", max="9") int aliasedIntDecl(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         @Interval(min="2", max="2") int temp = 2;
         this.intField = temp;
         // :: error: interval.return.type.incompatible
@@ -38,6 +46,13 @@ public final class ConcurrentSemanticsTest {
         // :: error: interval.return.type.incompatible
         return intField;
     }
+    public @Interval(min="0", max="9") int aliasedLaterIntDecl(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        this.leakThis();
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
     @EnsuresMaybeAliased(value="this")
     public @NonNull Object aliasedLaterObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
@@ -53,10 +68,15 @@ public final class ConcurrentSemanticsTest {
         this.intField = temp;
         return intField;
     }
+    public @Interval(min="0", max="9") int uniqueIntDecl(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        return intField;
+    }
     public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
 
-        // TODO This error is a false positive, but fixing requires
+        // TODO This error is a false positive, but fixing it requires
         //  either introducing a circular dependency between the packing and uniqueness checkers
         //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
         //  in the paper.

--- a/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTest/ConcurrentSemanticsTest.java
@@ -57,7 +57,7 @@ public final class ConcurrentSemanticsTest {
     public @NonNull Object aliasedLaterObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
         this.leakThis();
-        // :: error: nullness.return.type.incompatible :: error: packing.return.type.incompatible
+        // :: error: nullness.return.type.incompatible
         return objField;
     }
 
@@ -75,11 +75,6 @@ public final class ConcurrentSemanticsTest {
     }
     public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
-
-        // TODO This error is a false positive, but fixing it requires
-        //  either introducing a circular dependency between the packing and uniqueness checkers
-        //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
-        //  in the paper.
         // :: error: packing.return.type.incompatible
         return objField;
     }

--- a/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
@@ -10,7 +10,7 @@ import org.checkerframework.checker.initialization.qual.*;
 
 public final class ConcurrentSemanticsTest {
 
-    public int intField;
+    public @Interval(min="0", max="9") int intField = 3;
     public @Nullable Object objField;
 
     @EnsuresMaybeAliased(value="this")
@@ -19,6 +19,12 @@ public final class ConcurrentSemanticsTest {
     // this is aliased; thus another thread may write the field
 
     public @Interval(min="2", max="2") int aliasedInt(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        //// :: error: interval.return.type.incompatible
+        return intField;
+    }
+    public @Interval(min="0", max="9") int aliasedIntDecl(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         @Interval(min="2", max="2") int temp = 2;
         this.intField = temp;
         //// :: error: interval.return.type.incompatible
@@ -40,6 +46,13 @@ public final class ConcurrentSemanticsTest {
         // :: error: interval.return.type.incompatible
         return intField;
     }
+    public @Interval(min="0", max="9") int aliasedLaterIntDecl(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        this.leakThis();
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
     @EnsuresMaybeAliased(value="this")
     public @NonNull Object aliasedLaterObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
@@ -55,10 +68,15 @@ public final class ConcurrentSemanticsTest {
         this.intField = temp;
         return intField;
     }
+    public @Interval(min="0", max="9") int uniqueIntDecl(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        return intField;
+    }
     public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
 
-        // TODO This error is a false positive, but fixing requires
+        // TODO This error is a false positive, but fixing it requires
         //  either introducing a circular dependency between the packing and uniqueness checkers
         //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
         //  in the paper.

--- a/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
@@ -1,0 +1,68 @@
+import edu.kit.kastel.property.util.Packing;
+import edu.kit.kastel.property.checker.qual.*;
+import edu.kit.kastel.property.subchecker.exclusivity.qual.*;
+import edu.kit.kastel.property.subchecker.lattice.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+import edu.kit.kastel.property.packing.qual.*;
+import org.checkerframework.checker.initialization.qual.*;
+
+// Duplicate of ConcurrentSemanticsTest with sequential semantics
+
+public final class ConcurrentSemanticsTest {
+
+    public int intField;
+    public @Nullable Object objField;
+
+    @EnsuresMaybeAliased(value="this")
+    public void leakThis(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {}
+
+    // this is aliased; thus another thread may write the field
+
+    public @Interval(min="2", max="2") int aliasedInt(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        //// :: error: interval.return.type.incompatible
+        return intField;
+    }
+    public @NonNull Object aliasedObj(@MaybeAliased @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+        //// :: error: nullness.return.type.incompatible :: error: packing.return.type.incompatible
+        return objField;
+    }
+
+    // this is unique and becomes aliased; thus another thread may write the field
+
+    @EnsuresMaybeAliased(value="this")
+    public @Interval(min="2", max="2") int aliasedLaterInt(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        this.leakThis();
+        // :: error: interval.return.type.incompatible
+        return intField;
+    }
+    @EnsuresMaybeAliased(value="this")
+    public @NonNull Object aliasedLaterObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+        this.leakThis();
+        // :: error: nullness.return.type.incompatible :: error: packing.return.type.incompatible
+        return objField;
+    }
+
+    // this remains unique; thus the field cannot be written by another thread
+
+    public @Interval(min="2", max="2") int uniqueInt(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        @Interval(min="2", max="2") int temp = 2;
+        this.intField = temp;
+        return intField;
+    }
+    public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
+        this.objField = new Object();
+
+        // TODO This error is a false positive, but fixing requires
+        //  either introducing a circular dependency between the packing and uniqueness checkers
+        //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
+        //  in the paper.
+        //// :: error: packing.return.type.incompatible
+        return objField;
+    }
+}

--- a/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
+++ b/tests/property/ConcurrentSemanticsTestSequential/ConcurrentSemanticsTest.java
@@ -75,11 +75,6 @@ public final class ConcurrentSemanticsTest {
     }
     public @NonNull Object uniqueObj(@Unique @UnknownInitialization(Object.class) ConcurrentSemanticsTest this) {
         this.objField = new Object();
-
-        // TODO This error is a false positive, but fixing it requires
-        //  either introducing a circular dependency between the packing and uniqueness checkers
-        //  or adding a feature to the uniqueness checker to restrict borrowings of "this" similar to the formalization
-        //  in the paper.
         //// :: error: packing.return.type.incompatible
         return objField;
     }

--- a/tests/property/DefaultTest/NullnessDefaultTest.java
+++ b/tests/property/DefaultTest/NullnessDefaultTest.java
@@ -9,11 +9,11 @@ import org.checkerframework.dataflow.qual.*;
 
 public class NullnessDefaultTest {
 
-    // :: error: initialization.static.field.uninitialized
+    // :: error: nullness.initialization.static.field.uninitialized
     static @NonNull Object staticNonNullField;
     static @Nullable Object staticNullableField;
     static @MonotonicNonNull Object staticMonotonicNonNullField;
-    // :: error: initialization.static.field.uninitialized
+    // :: error: nullness.initialization.static.field.uninitialized
     static Object staticDefaultField;
 
     // :: error: nullness.initialization.field.uninitialized


### PR DESCRIPTION
Various fixes and improvements when using `-AconcurrentSemantics` with the Property Checker. See https://eisop.github.io/cf/manual/manual.html#faq-concurrency